### PR TITLE
feat: Enable specifics gGRPC services.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,14 @@ ENV	URL_REPO="https://github.com/adempiere/adempiere-gRPC-Server" \
 	BASE_VERSION="rt-18.1" \
 	BINARY_NAME="adempiere-gRPC-Server.zip" \
 	SERVER_PORT="50059" \
+	SERVICES_ENABLED="access; business; core; dashboarding; dictionary; enrollment; log; ui; workflow; store; pos;" \
+	SERVER_LOG_LEVEL="WARNING" \
 	DB_HOST="localhost" \
 	DB_PORT="5432" \
 	DB_NAME="adempiere" \
+	DB_USER="adempiere" \
 	DB_PASSWORD="adempiere" \
-	DB_TYPE="PostgreSQL" \
-	SERVER_LOG_LEVEL="WARNING"
+	DB_TYPE="PostgreSQL"
 
 # Add system dependencies
 RUN	echo "http://mirrors.aliyun.com/alpine/latest-stable/main/" > /etc/apk/repositories && \
@@ -35,18 +37,10 @@ RUN	mkdir -p /opt/Apps && \
 	mv adempiere-gRPC-Server ADempiere-gRPC-Server && \
 	rm $BINARY_NAME
 
-# Add connection template
-COPY all_in_one_connection.yaml /opt/Apps/ADempiere-gRPC-Server/bin/all_in_one_connection.yaml
+# Add connection template and start script files
+COPY "all_in_one_connection.yaml" "start.sh" "/opt/Apps/ADempiere-gRPC-Server/bin/"
 
 WORKDIR /opt/Apps/ADempiere-gRPC-Server/bin/
 
-# Set ENV in the connection file
-CMD	sed -i "s|50059|$SERVER_PORT|g" all_in_one_connection.yaml && \
-	sed -i "s|localhost|$DB_HOST|g" all_in_one_connection.yaml && \
-	sed -i "s|5432|$DB_PORT|g" all_in_one_connection.yaml && \
-	sed -i "s|adempieredb|$DB_NAME|g" all_in_one_connection.yaml && \
-	sed -i "s|adempiereuser|$DB_USER|g" all_in_one_connection.yaml && \
-	sed -i "s|adempierepass|$DB_PASSWORD|g" all_in_one_connection.yaml && \
-	sed -i "s|PostgreSQL|$DB_TYPE|g" all_in_one_connection.yaml && \
-	sed -i "s|WARNING|$SERVER_LOG_LEVEL|g" all_in_one_connection.yaml && \
-	'sh' 'adempiere-all-in-one-server' 'all_in_one_connection.yaml'
+# Start app
+CMD	'sh' 'start.sh'

--- a/README.md
+++ b/README.md
@@ -63,23 +63,26 @@ docker run -d \
     -it \
     --name adempiere-grpc-all-in-one \
     -p 50059:50059 \
-    -e "SERVER_PORT=50059" \
-    -e "DB_HOST=Your-Database-Server-Address" \
-    -e "DB_NAME=Your-Database-Name" \
-    -e "DB_USER=Your-Database-User" \
-    -e "DB_PASSWORD=Your-Database-Password" \
-    -e "DB_TYPE=Your-Database-Type" \
-    -e "SERVER_LOG_LEVEL=Log Level (Default Warning)" \
+    -e SERVER_PORT=50059 \
+	-e SERVICES_ENABLED="access; business; core; dashboarding; dictionary; enrollment; log; ui; workflow; store; pos;" \
+    -e SERVER_LOG_LEVEL="Log Level (Default Warning)" \
+    -e DB_HOST="Your-Database-Server-Address" \
+    -e DB_PORT="Your-Database-Server-Port" \
+    -e DB_NAME="Your-Database-Name" \
+    -e DB_USER="Your-Database-User" \
+    -e DB_PASSWORD="Your-Database-Password" \
+    -e DB_TYPE="Your-Database-Type" \
     erpya/adempiere-grpc-all-in-one
 ```
 
 ## Environment variables for the configuration
 
  * `SERVER_PORT`: Indicates the port on which the gRPC service will start, by default its value is `50059`. Make sure that it is set to the same value as the TCP port in the container.
+ * `SERVICES_ENABLED`: Services to be enabled in the gRPC server, separated by spaces or semicolons `;`, by default is `access; business; core; dashboarding; dictionary; enrollment; log; ui; workflow; store; pos;`.
+ * `SERVER_LOG_LEVEL`: Log Level for Server, by default is `WARNING`.
  * `DB_HOST`: Database server address, by default its value is `localhost`.
  * `DB_PORT`: Indicates the database listening port, by default its value is `5432`.
  * `DB_NAME`: Name of the database, by default its value is `adempiere`.
  * `DB_USER`: Database connection user, by default its value is `adempiere`.
  * `DB_PASSWORD`: Password of the database connection, by default its value is `adempiere`.
  * `DB_TYPE`: Database management system, by default is `PostgreSQL`.
- * `SERVER_LOG_LEVEL`: Log Level for Server, by default is `WARNING`.

--- a/all_in_one_connection.yaml
+++ b/all_in_one_connection.yaml
@@ -1,17 +1,7 @@
 server:
     port: 50059
     services:
-       -   access
-       -   business
-       -   core
-       -   dashboarding
-       -   dictionary
-       -   enrollment
-       -   log
-       -   ui
-       -   workflow
-       -   store
-       -   pos
+        - services_enabled
     log_level: WARNING
 database:
     host: localhost

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env sh
+# @autor Edwin Betancourt <EdwinBetanc0urt@outlook.com>
+
+# Set server values
+sed -i "s|50059|$SERVER_PORT|g" all_in_one_connection.yaml
+sed -i "s|WARNING|$SERVER_LOG_LEVEL|g" all_in_one_connection.yaml
+
+
+# create array to iterate
+SERVICES_LIST=$(echo $SERVICES_ENABLED | tr "; " "\n")
+
+SERVICES_LIST_TO_SET=""
+for SERVICE_ITEM in $SERVICES_LIST
+do
+    # Service to lower case
+    SERVICE_LOWER_CASE=$(echo $SERVICE_ITEM | tr '[:upper:]' '[:lower:]')
+
+    NEW_LINE="\n"
+    PREFIX="        - "
+    if [ -z "$SERVICES_LIST_TO_SET" ]
+    then
+        NEW_LINE=""
+        PREFIX="- "
+    fi
+
+    # Add to the list of services
+    SERVICES_LIST_TO_SET="${SERVICES_LIST_TO_SET}${NEW_LINE}${PREFIX}${SERVICE_LOWER_CASE}"
+done
+
+sed -i "s|- services_enabled|$SERVICES_LIST_TO_SET|g" all_in_one_connection.yaml
+
+
+# Set data base conection values
+sed -i "s|localhost|$DB_HOST|g" all_in_one_connection.yaml
+sed -i "s|5432|$DB_PORT|g" all_in_one_connection.yaml
+sed -i "s|adempieredb|$DB_NAME|g" all_in_one_connection.yaml
+sed -i "s|adempiereuser|$DB_USER|g" all_in_one_connection.yaml
+sed -i "s|adempierepass|$DB_PASSWORD|g" all_in_one_connection.yaml
+sed -i "s|PostgreSQL|$DB_TYPE|g" all_in_one_connection.yaml
+
+
+# Run app
+./adempiere-all-in-one-server ./all_in_one_connection.yaml


### PR DESCRIPTION
The services of the gRPC backend are turned on through the environment variable `SERVICES_ENABLED`, if no value is set, by default it takes the value `access; business; core; dashboarding; dictionary; enrollment; log; ui; workflow; store; pos;` enabling all services.

These environment variable values are set in the configuration file all_in_one_connection.yaml within the server > services key:

```yaml
server:
    services:
       -   access
       -   business
       -   core
       -   dashboarding
       -   dictionary
       -   enrollment
       -   log
       -   ui
       -   workflow
       -   store
```

NOTE: Each service must be separated by space, semicolon `;` or the previous two combined.